### PR TITLE
Fixed typo in validate_api

### DIFF
--- a/validate_api.c
+++ b/validate_api.c
@@ -1233,7 +1233,7 @@ int detach_after_join_main_thread(int argl, void* args)
 {
 
  	Tid_t joined_tid = CreateThread(detach_after_join_joined_thread, 0, NULL);
- 	ASSERT(joined_thread != NOTHREAD);
+ 	ASSERT(joined_tid != NOTHREAD);
 
 	Tid_t tids[5];
 	for(int i=0;i<5;i++) {


### PR DESCRIPTION
it previously asserted that  SOME_FUNC != NOTHREAD

which beside not testing for anything (is always true)
also produces a compiler warning